### PR TITLE
Correct gem name in documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,7 @@ the tab name as an ItermWindow method.
 == EXAMPLE - Open a new iTerm window, cd to a project and open it in TextMate
 
   require 'rubygems'
-  require 'chrisjpowers-iterm_window'
+  require 'iterm_window'
 
   ItermWindow.open do
     open_tab :my_tab do


### PR DESCRIPTION
`require 'chrisjpowers-iterm_window'` was raising an error. I changed the `require` argument to `'iterm_window'`, and everything worked.
