### PR TITLE
Fix shell_out to interpolate the command into the %x{} 

### DIFF
--- a/lib/iterm_window.rb
+++ b/lib/iterm_window.rb
@@ -146,7 +146,7 @@ class ItermWindow
   end
 
   def shell_out(str)
-    %x{str}
+    %x(#{str})
   end
 
 

--- a/spec/iterm_window_spec.rb
+++ b/spec/iterm_window_spec.rb
@@ -118,4 +118,12 @@ describe ItermWindow do
       end
     end
   end
+  
+  describe "shell_out" do
+    it "makes shell call" do
+      desired = "ls"
+      lambda{ @window.send("shell_out",desired)}.should_not raise_error
+      
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-require 'spec'
+require 'rspec'
 require File.join(File.dirname(__FILE__), '..', 'lib', 'iterm_window.rb')


### PR DESCRIPTION
shell_out does %w{str} where _str_ is the concatenated applescript command as a String. 

Without string interpolation it trys to run a shell command called _str_ which fails.

Now it works as expected- tested with RSpec and also by using it in a few automation scripts
